### PR TITLE
Set a socket timeout

### DIFF
--- a/nad_receiver/__init__.py
+++ b/nad_receiver/__init__.py
@@ -169,6 +169,7 @@ class NADReceiverTCP(object):
         for tries in range(0, 3):
             try:
                 sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+                sock.settimeout(5.0)
                 sock.connect((self._host, self.PORT))
                 break
             except (ConnectionError, BrokenPipeError):


### PR DESCRIPTION
When I try to set the same source twice on my NAD 7050 the script will hang as the receiver don't give any response.
Prevent this by applying a timeout to the socket.

reproduce:
d7050.select_source('Optical 1')
d7050.select_source('Optical 1')