### PR TITLE
Fix NAD7050 hangs with identical settings

### DIFF
--- a/nad_receiver/__init__.py
+++ b/nad_receiver/__init__.py
@@ -222,11 +222,16 @@ class NADReceiverTCP(object):
 
     def power_off(self):
         """Power the device off."""
-        self._send(self.CMD_POWERSAVE + self.CMD_OFF)
+        status = self.status()
+        if status['power']:  # Setting power off when it is already off can cause hangs
+            self._send(self.CMD_POWERSAVE + self.CMD_OFF)
 
     def power_on(self):
         """Power the device on."""
-        self._send(self.CMD_ON, read_reply=True)
+        status = self.status()
+        if not status['power']:
+            self._send(self.CMD_ON, read_reply=True)
+            sleep(0.5)  # Give NAD7050 some time before next command
 
     def set_volume(self, volume):
         """Set volume level of the device. Accepts integer values 0-200."""
@@ -241,11 +246,14 @@ class NADReceiverTCP(object):
     def unmute(self):
         """Unmute the device."""
         self._send(self.CMD_UNMUTE)
-
+ 
     def select_source(self, source):
         """Select a source from the list of sources."""
-        if source in self.SOURCES:
-            self._send(self.CMD_SOURCE + self.SOURCES[source], read_reply=True)
+        status = self.status()
+        if status['power']:  # Changing source when off may hang NAD7050
+            if status['source'] not in source:  # Setting the source to the current source will hang the NAD7050
+                if source in self.SOURCES:
+                    self._send(self.CMD_SOURCE + self.SOURCES[source], read_reply=True)
 
     def available_sources(self):
         """Return a list of available sources."""

--- a/nad_receiver/__init__.py
+++ b/nad_receiver/__init__.py
@@ -251,7 +251,7 @@ class NADReceiverTCP(object):
         """Select a source from the list of sources."""
         status = self.status()
         if status['power']:  # Changing source when off may hang NAD7050
-            if status['source'] not in source:  # Setting the source to the current source will hang the NAD7050
+            if status['source'] != source:  # Setting the source to the current source will hang the NAD7050
                 if source in self.SOURCES:
                     self._send(self.CMD_SOURCE + self.SOURCES[source], read_reply=True)
 


### PR DESCRIPTION
Fix NAD7050 hangs when setting source or power to the value it already has, as well as a hang when setting the source while the power is off. This normally only occurs in automations, because normally only commands are send when the status changes, but in an automation people can choose to just set things without first checking the current status. This is the same fix as I copy-pasted in comments on #4 