### PR TITLE
Wait for the requested response

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,11 @@
 # nad_receiver
-Simple python API to connect to NAD receivers through the RS232 interface, and to the NAD D 7050 amplifier via tcp/ip. For the RS232 interface use the NADReceiver class, for the D 7050 use the D7050 class.
+Simple python API to connect to NAD receivers through the RS232 interface, Telnet interface or the TCP/IP interface.
+For the RS232 interface use the NADReceiver class
+For the Telnet interface use the NADReceiverTelnet class
+For the TCP/IP interface use the D7050 class
 
 Note that the RS232 interface is only tested with the NAD T748v2. Commands are implemented based on the T748v2. Those commands should work with more NAD receivers.
+The Telnet interface is only tested with the NAD T787. The Telnet interface share documentation with the RS232 interface and supports the same commands
 The supported commands can easily be extended for receivers which support more commands.
 
 For more information see the official documentation at http://nadelectronics.com/software 
@@ -26,6 +30,13 @@ D7050.select_source('Optical 1')
 D7050.mute()
 D7050.unmute()
 D7050.power_off()
+
+receiver = NADReceiverTelnet(my_nad.local)
+
+receiver.main_volume('+')  #  will increase volume with 1 and return new value
+receiver.main_volume('-')  #  will decrease volume with 1 and return new value
+receiver.main_volume('=', '-40')  # specify dB, will return new value
+print(receiver.main_volume('?'))  # will return current value
 ```
 
 supported commands with supported operators for the RS232 interface

--- a/nad_receiver/__init__.py
+++ b/nad_receiver/__init__.py
@@ -300,12 +300,17 @@ class NADReceiverTelnet(NADReceiver):
 
         # Not possible to test for open Telnet connection
         # let is raise if any issues
-        # Yes, for telnet the first \r / \n is recommended only
-        self.telnet.write((''.join([cmd, '\n']).encode()))
+        # For telnet the first \r / \n is recommended only
+        self.telnet.write((''.join(['\r', cmd, '\n']).encode()))
 
-        msg = self.telnet.read_until('\n'.encode(), self.timeout)
-        msg = msg.decode().strip('\r\n')
-        #print("NAD reponded with '%s'" % msg)
+        found = False
+        while not found:
+            msg = self.telnet.read_until('\n'.encode(), self.timeout)
+            msg = msg.decode().strip('\r\n')
+            #print("NAD reponded with '%s'" % msg)
+            # Wait for the response that equals the requested domain.function
+            if msg.strip().split('=')[0].lower() == '.'.join([domain, function]).lower():
+                found = True
 
         return msg.strip().split('=')[1]
         # b'Main.Volume=-12\r will return -12


### PR DESCRIPTION
When sending a telnet request and at the same time
using the remote control the reponse was sometimes
incorrect. This solution is probably not 100%

Eg. sending main.volume? while fibbling with the remote
does not guarantee that the response is for the
main.volume? command, it could be a response
from remote control volume changes. But filtering
should work for e.g. main.power? while pressing
vol+/- on the remote

Tested within home-assistant