### PR TITLE
Added timeout to socket connection

### DIFF
--- a/nad_receiver/__init__.py
+++ b/nad_receiver/__init__.py
@@ -161,11 +161,13 @@ class NADReceiverTCP(object):
         sock = None
         for tries in range(0, 3):
             try:
-                sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-                sock.connect((self._host, self.PORT))
+                sock = socket.create_connection((self._host, self.PORT), timeout=5)
                 break
+            except socket.timeout:
+                print("Socket connection timed out.")
+                return
             except (ConnectionError, BrokenPipeError):
-                if tries == 3:
+                if tries == 2:
                     print("socket connect failed.")
                     return
                 sleep(0.1)


### PR DESCRIPTION
I noticed that sometimes my amp would stop listening to socket connections. Unfortunately the only way to remedy this is to power toggle my amp. Anyway, the home assistant NAD component would get stuck in the update. Therefor I added a timeout to the socket connect.