### PR TITLE
Transports

### DIFF
--- a/nad_receiver/nad_commands.py
+++ b/nad_receiver/nad_commands.py
@@ -41,7 +41,23 @@ CMDS = {
             'version':
                 {'cmd': 'Main.Version',
                  'supported_operators': ['?']
-                 }
+                 },
+            'speaker_a':
+                {'cmd': 'Main.SpeakerA',
+                 'supported_operators': ['+', '-', '=', '?'],
+                 },
+            'speaker_b':
+                {'cmd': 'Main.SpeakerB',
+                 'supported_operators': ['+', '-', '=', '?'],
+                 },
+            'tape_monitor':
+                {'cmd': 'Main.Tape1',
+                 'supported_operators': ['+', '-', '=', '?'],
+                 },
+            'model':
+                {'cmd': 'Main.Model',
+                 'supported_operators': ['?']
+                 },
         },
     'tuner':
         {

--- a/nad_receiver/nad_transport.py
+++ b/nad_receiver/nad_transport.py
@@ -1,0 +1,88 @@
+import abc
+import codecs
+import serial  # type: ignore
+import telnetlib
+import threading
+import time
+import socket
+
+from typing import Optional
+
+import logging
+
+logging.basicConfig()
+_LOGGER = logging.getLogger("nad_receiver.transport")
+
+
+DEFAULT_TIMEOUT = 1
+
+
+class NadTransport(abc.ABC):
+    @abc.abstractmethod
+    def communicate(self, command: str) -> str:
+        pass
+
+
+class SerialPortTransport:
+    """Transport for NAD protocol over RS-232."""
+
+    def __init__(self, serial_port: str) -> None:
+        """Create RS232 connection."""
+        self.ser = serial.Serial(
+            serial_port,
+            baudrate=115200,
+            timeout=DEFAULT_TIMEOUT,
+            write_timeout=DEFAULT_TIMEOUT,
+        )
+        self.lock = threading.Lock()
+
+    def _open_connection(self) -> None:
+        if not self.ser.is_open:
+            self.ser.open()
+            _LOGGER.debug("serial open: %s", self.ser.is_open)
+
+    def communicate(self, command: str) -> str:
+        with self.lock:
+            self._open_connection()
+
+            self.ser.write(f"\r{command}\r".encode("utf-8"))
+            # To get complete messages, always read until we get '\r'
+            # Messages will be of the form '\rMESSAGE\r' which pyserial handles nicely
+            msg = self.ser.read_until("\r")
+            assert isinstance(msg, bytes)
+            return msg.strip().decode()
+
+
+class TelnetTransport:
+    """
+    Support NAD amplifiers that use telnet for communication.
+    Supports all commands from the RS232 base class
+
+    Known supported model: Nad T787.
+    """
+
+    def __init__(self, host: str, port: int, timeout: int) -> None:
+        """Create NADTelnet."""
+        self.telnet: Optional[telnetlib.Telnet] = None
+        self.host = host
+        self.port = port
+        self.timeout = timeout
+
+    def _open_connection(self) -> None:
+        if not self.telnet:
+            try:
+                self.telnet = telnetlib.Telnet(self.host, self.port, 3)
+                # Some versions of the firmware report Main.Model=T787.
+                # some versions do not, we want to clear that line
+                self.telnet.read_until("\n".encode(), self.timeout)
+                # Could raise eg. EOFError, UnicodeError
+            except (EOFError, UnicodeError):
+                pass
+
+    def communicate(self, cmd: str) -> str:
+        self._open_connection()
+        assert self.telnet
+
+        self.telnet.write(f"\r{cmd}\r".encode())
+        msg = self.telnet.read_until(b"\r", self.timeout)
+        return msg.strip().decode()


### PR DESCRIPTION
    Introduce transports
    
    The rs232 code and telnet are basically the same. The official NAD
    documentation confirms this, the data sent must be identical for both
    protocols.
    Abstract the difference away in simple classes instead of having
    duplicate code.
    
    The TCP class looks sufficiently different, since I cannot test that, I
    do not dare touching it.
    
    This also fixes the need for a 0.5 second wait in the serial port
    connection by rather reading until a '\r' is received.
    Works more reliably for my receiver and I assume all models.
    
    Add a first test to be able to verify different device's protocols.
