### PR TITLE
Fix volume

### DIFF
--- a/nad_receiver/__init__.py
+++ b/nad_receiver/__init__.py
@@ -77,15 +77,14 @@ class NADReceiver(object):
         """Execute Main.Power."""
         return self.exec_command('main', 'power', operator, value)
 
-    def main_volume(self, operator, value=None):
+    def main_volume(self, operator: str, value=None) -> float:
         """
         Execute Main.Volume.
 
-        Returns int
+        Returns float
         """
         try:
-            res = int(round(
-                self.exec_command('main', 'volume', operator, value)))
+            res = float(self.exec_command('main', 'volume', operator, value))
             return res
 
         except (ValueError, TypeError):


### PR DESCRIPTION
In 5b9e7e711f18ca1f613b16231c31ac9085070e86 an attempt was made to adapt
the code to support receivers that return float volumes ('-41.5') but
that change made things worse, since round(string) will never work.
round() takes a number, not a string.

Let's be more precise and return the volume as float.
Alternatively we could do int(float(volume)) but that doesn't seem like
an improvement. At least the home assistant code will deal with the
change from int to float just fine.