### PR TITLE
Add logging

### DIFF
--- a/nad_receiver/__init__.py
+++ b/nad_receiver/__init__.py
@@ -12,6 +12,14 @@ from nad_receiver.nad_commands import CMDS
 from nad_receiver.nad_transport import (SerialPortTransport, TelnetTransport,
                                         DEFAULT_TIMEOUT)
 
+import logging
+
+
+logging.basicConfig()
+_LOGGER = logging.getLogger("nad_receiver")
+# Uncomment this line to see all communication with the device:
+# _LOGGER.setLevel(logging.DEBUG)
+
 
 class NADReceiver:
     """NAD receiver."""
@@ -40,6 +48,7 @@ class NADReceiver:
 
         try:
             msg = self.transport.communicate(cmd)
+            _LOGGER.debug(f"sent: '{cmd}' reply: '{msg}'")
             return msg.split('=')[1]
         except IndexError:
             pass


### PR DESCRIPTION
Just the very basic infrastructure to make debugging easier.
Since most people have only one receiver, we need to be able to capture logs.

One option for users is to simply uncomment one line to enable logging
of all communication through serial or telnet.