### PR TITLE
Experiment: Try to clear telnet buffer on connecting

### DIFF
--- a/nad_receiver/nad_transport.py
+++ b/nad_receiver/nad_transport.py
@@ -72,7 +72,9 @@ class TelnetTransport:
                 self.telnet = telnetlib.Telnet(self.host, self.port, 3)
                 # Some versions of the firmware report Main.Model=T787.
                 # some versions do not, we want to clear that line
+                self.telnet.read_lazy()
                 self.telnet.read_until("\n".encode(), self.timeout)
+                self.telnet.read_lazy()
                 # Could raise eg. EOFError, UnicodeError
             except (EOFError, UnicodeError):
                 pass


### PR DESCRIPTION
Depending on the firmware, the device seems to send a whole state dump on connection.
Try to not get ourselves confused by just discarding all the data.

I suggest not to merge this, unless it helps @andreas-amlabs .