### PR TITLE
Make sure to read the actual message when just '\r' is received

### DIFF
--- a/nad_receiver/nad_transport.py
+++ b/nad_receiver/nad_transport.py
@@ -47,6 +47,8 @@ class SerialPortTransport:
             # Messages will be of the form '\rMESSAGE\r' which
             # pyserial handles nicely
             msg = self.ser.read_until("\r")
+            if not msg.strip():  # discard '\r' if it was sent
+                msg = self.ser.read_until("\r")
             assert isinstance(msg, bytes)
             return msg.strip().decode()
 


### PR DESCRIPTION
I'm surprised that the previous code worked, I should have broken something.
It seems to be a bit model dependent though, but the devices seem
relatively consistent in sending b'\rmessage\r', so always read until '\r',
check if that is empty, in which case reading until the next '\r' should give
the message.