### PR TITLE
Add type information everywhere

### DIFF
--- a/nad_receiver/nad_fake_transport.py
+++ b/nad_receiver/nad_fake_transport.py
@@ -1,5 +1,6 @@
 from nad_receiver.nad_transport import NadTransport
 import re
+from typing import Callable, Optional
 
 class Fake_NAD_C_356BE_Transport(NadTransport):
     """A fake NAD C 356BE device.
@@ -9,7 +10,7 @@ class Fake_NAD_C_356BE_Transport(NadTransport):
     library into other applications, such as Home Assistant.
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         self._toggle = {
             "Power": False,
             "Mute": False,
@@ -44,7 +45,7 @@ class Fake_NAD_C_356BE_Transport(NadTransport):
         operator = match.group("operator")
         value = match.group("value")
 
-        response = lambda val: f"{component}.{function}{'=' + val if val else ''}"
+        response: Callable[[Optional[str]], str] = lambda val: f"{component}.{function}{'=' + val if val else ''}"
 
         if function == "Version" and operator == "?":
             return response(self._version)

--- a/nad_receiver/nad_transport.py
+++ b/nad_receiver/nad_transport.py
@@ -20,7 +20,7 @@ class NadTransport(abc.ABC):
         pass
 
 
-class SerialPortTransport:
+class SerialPortTransport(NadTransport):
     """Transport for NAD protocol over RS-232."""
 
     def __init__(self, serial_port: str) -> None:
@@ -53,7 +53,7 @@ class SerialPortTransport:
             return msg.strip().decode()
 
 
-class TelnetTransport:
+class TelnetTransport(NadTransport):
     """
     Support NAD amplifiers that use telnet for communication.
     Supports all commands from the RS232 base class

--- a/tests/test_nad_protocol.py
+++ b/tests/test_nad_protocol.py
@@ -10,11 +10,11 @@ OFF = "Off"
 
 class Fake_NAD_C_356BE(nad_receiver.NADReceiver):
     """NAD Receiver with fake transport for testing."""
-    def __init__(self):
+    def __init__(self) -> None:
         self.transport = Fake_NAD_C_356BE_Transport()
 
 
-def test_NAD_C_356BE():
+def test_NAD_C_356BE() -> None:
     # This test can be run with the real amplifier, just instantiate
     # the real transport instead of the fake one
     receiver = Fake_NAD_C_356BE()


### PR DESCRIPTION
Now that we check types with mypy, use the type information.
This uncovered for example that the transport subclasses did not
actually inherit the base class.