### PR TITLE
NAD Testing. Allow for easy testing of each NAD unit type

### DIFF
--- a/nad_receiver/nad_fake_transport.py
+++ b/nad_receiver/nad_fake_transport.py
@@ -105,3 +105,24 @@ class Fake_NAD_C_356BE_Transport(Fake_NAD_Transport):
         self._command_regex = re.compile(
             r"(?P<component>\w+)\.(?P<function>\w+)(?P<operator>[=\?\+\-])(?P<value>.*)"
         )
+
+
+class Fake_NAD_Telnet_Transport(Fake_NAD_Transport):
+    """A fake NAD Telnet device.
+    """
+
+    def __init__(self) -> None:
+        self._toggle = {
+            "Power": False,
+            "Mute": False,
+            "Tape1": False,
+            "SpeakerA": True,
+            "SpeakerB": False,
+        }
+        self._model = "T787"
+        self._version = "V2.10"
+        self._sources = "CD TUNER DISC/MDC AUX TAPE2 MP".split()
+        self._source = "CD"
+        self._command_regex = re.compile(
+            r"(?P<component>\w+)\.(?P<function>\w+)(?P<operator>[=\?\+\-])(?P<value>.*)"
+        )

--- a/nad_receiver/nad_fake_transport.py
+++ b/nad_receiver/nad_fake_transport.py
@@ -102,9 +102,6 @@ class Fake_NAD_C_356BE_Transport(Fake_NAD_Transport):
         self._version = "V1.02"
         self._sources = "CD TUNER DISC/MDC AUX TAPE2 MP".split()
         self._source = "CD"
-        self._command_regex = re.compile(
-            r"(?P<component>\w+)\.(?P<function>\w+)(?P<operator>[=\?\+\-])(?P<value>.*)"
-        )
 
 
 class Fake_NAD_Telnet_Transport(Fake_NAD_Transport):
@@ -123,6 +120,3 @@ class Fake_NAD_Telnet_Transport(Fake_NAD_Transport):
         self._version = "V2.10"
         self._sources = "CD TUNER DISC/MDC AUX TAPE2 MP".split()
         self._source = "CD"
-        self._command_regex = re.compile(
-            r"(?P<component>\w+)\.(?P<function>\w+)(?P<operator>[=\?\+\-])(?P<value>.*)"
-        )

--- a/nad_receiver/nad_fake_transport.py
+++ b/nad_receiver/nad_fake_transport.py
@@ -2,8 +2,8 @@ from nad_receiver.nad_transport import NadTransport
 import re
 from typing import Callable, Optional
 
-class Fake_NAD_C_356BE_Transport(NadTransport):
-    """A fake NAD C 356BE device.
+class Fake_NAD_Transport(NadTransport):
+    """A fake NAD device.
 
     Behaves just like the real device (although faster).
     This is convenient for testing or when integrating this
@@ -18,10 +18,10 @@ class Fake_NAD_C_356BE_Transport(NadTransport):
             "SpeakerA": True,
             "SpeakerB": False,
         }
-        self._model = "C356BEE"
-        self._version = "V1.02"
-        self._sources = "CD TUNER DISC/MDC AUX TAPE2 MP".split()
-        self._source = "CD"
+        self._model = "FAKE"
+        self._version = "FAKE"
+        self._sources = ["FAKE"]
+        self._source = "FAKE"
         self._command_regex = re.compile(
             r"(?P<component>\w+)\.(?P<function>\w+)(?P<operator>[=\?\+\-])(?P<value>.*)"
         )
@@ -84,3 +84,24 @@ class Fake_NAD_C_356BE_Transport(NadTransport):
             return response(self._source)
 
         return ""
+
+
+class Fake_NAD_C_356BE_Transport(Fake_NAD_Transport):
+    """A fake NAD C 356BE device.
+    """
+
+    def __init__(self) -> None:
+        self._toggle = {
+            "Power": False,
+            "Mute": False,
+            "Tape1": False,
+            "SpeakerA": True,
+            "SpeakerB": False,
+        }
+        self._model = "C356BEE"
+        self._version = "V1.02"
+        self._sources = "CD TUNER DISC/MDC AUX TAPE2 MP".split()
+        self._source = "CD"
+        self._command_regex = re.compile(
+            r"(?P<component>\w+)\.(?P<function>\w+)(?P<operator>[=\?\+\-])(?P<value>.*)"
+        )

--- a/tests/test_nad_protocol.py
+++ b/tests/test_nad_protocol.py
@@ -3,10 +3,16 @@ import operator
 import pytest  # type: ignore
 
 import nad_receiver
-from nad_receiver.nad_fake_transport import Fake_NAD_C_356BE_Transport
+from nad_receiver.nad_fake_transport import *
 
 ON = "On"
 OFF = "Off"
+
+
+class Fake_NAD_Telnet(nad_receiver.NADReceiver):
+    """NAD Receiver with fake transport for testing."""
+    def __init__(self) -> None:
+        self.transport = Fake_NAD_Telnet_Transport()
 
 
 class Fake_NAD_C_356BE(nad_receiver.NADReceiver):
@@ -15,76 +21,86 @@ class Fake_NAD_C_356BE(nad_receiver.NADReceiver):
         self.transport = Fake_NAD_C_356BE_Transport()
 
 
-SerialTests=[
-("receiver.main_power", "=", OFF, operator.eq),
-("receiver.main_power", "?", OFF, operator.eq),
-("receiver.main_power", "+", ON, operator.eq),
-("receiver.main_power", "+", OFF, operator.eq),
-("receiver.main_power", "?", OFF, operator.eq),
-("receiver.main_mute", "?", None, operator.is_),
+CommonTests = [
+    ("receiver.main_power", "=", OFF, operator.eq),
+    ("receiver.main_power", "?", OFF, operator.eq),
+    ("receiver.main_power", "+", ON, operator.eq),
+    ("receiver.main_power", "+", OFF, operator.eq),
+    ("receiver.main_power", "?", OFF, operator.eq),
+    ("receiver.main_mute", "?", None, operator.is_),
 
-("receiver.main_power", "=", ON, operator.eq),
-("receiver.main_power", "?", ON, operator.eq),
+    ("receiver.main_power", "=", ON, operator.eq),
+    ("receiver.main_power", "?", ON, operator.eq),
 
-("receiver.main_mute", "=", OFF, operator.eq),
-("receiver.main_mute", "?", OFF, operator.eq),
+    ("receiver.main_mute", "=", OFF, operator.eq),
+    ("receiver.main_mute", "?", OFF, operator.eq),
 
-# Not a feature for this amp
-("receiver.main_dimmer", "?", None, operator.is_),
+    # Not a feature for this amp
+    ("receiver.main_dimmer", "?", None, operator.is_),
 
-# Stepper motor and this thing has no idea about the volume
-("receiver.main_volume", "?", None, operator.is_),
+    # Stepper motor and this thing has no idea about the volume
+    ("receiver.main_volume", "?", None, operator.is_),
 
-# No exception
-("receiver.main_volume", "+", None, operator.is_),
-("receiver.main_volume", "-", None, operator.is_),
+    # No exception
+    ("receiver.main_volume", "+", None, operator.is_),
+    ("receiver.main_volume", "-", None, operator.is_),
 
-("receiver.main_version", "?", "V1.02", operator.eq),
-("receiver.main_model", "?", "C356BEE", operator.eq),
+    # Here the RS232 NAD manual seems to be slightly off / maybe the model is different
+    # The manual claims:
+    # CD Tuner Video Disc Ipod Tape2 Aux
+    # My Amp:
+    # CD Tuner Disc/MDC Aux Tape2 MP
+    # Protocol V2 represents sources as strings, we should get these:
+    ("receiver.main_source", "=", "AUX", operator.eq),
+    ("receiver.main_source", "?", "AUX", operator.eq),
+    ("receiver.main_source", "=", "CD", operator.eq),
+    ("receiver.main_source", "?", "CD", operator.eq),
+    ("receiver.main_source", "+", "TUNER", operator.eq),
+    ("receiver.main_source", "-", "CD", operator.eq),
+    ("receiver.main_source", "+", "TUNER", operator.eq),
+    ("receiver.main_source", "+", "DISC/MDC", operator.eq),
+    ("receiver.main_source", "+", "AUX", operator.eq),
+    ("receiver.main_source", "+", "TAPE2", operator.eq),
+    ("receiver.main_source", "+", "MP", operator.eq),
+    ("receiver.main_source", "+", "CD", operator.eq),
+    ("receiver.main_source", "-", "MP", operator.eq),
 
-# Here the RS232 NAD manual seems to be slightly off / maybe the model is different
-# The manual claims:
-# CD Tuner Video Disc Ipod Tape2 Aux
-# My Amp:
-# CD Tuner Disc/MDC Aux Tape2 MP
-# Protocol V2 represents sources as strings, we should get these:
-("receiver.main_source", "=", "AUX", operator.eq),
-("receiver.main_source", "?", "AUX", operator.eq),
-("receiver.main_source", "=", "CD", operator.eq),
-("receiver.main_source", "?", "CD", operator.eq),
-("receiver.main_source", "+", "TUNER", operator.eq),
-("receiver.main_source", "-", "CD", operator.eq),
-("receiver.main_source", "+", "TUNER", operator.eq),
-("receiver.main_source", "+", "DISC/MDC", operator.eq),
-("receiver.main_source", "+", "AUX", operator.eq),
-("receiver.main_source", "+", "TAPE2", operator.eq),
-("receiver.main_source", "+", "MP", operator.eq),
-("receiver.main_source", "+", "CD", operator.eq),
-("receiver.main_source", "-", "MP", operator.eq),
+    # Tape monitor / tape 1 is independent of sources
+    ("receiver.main_tape_monitor", "=", OFF, operator.eq),
+    ("receiver.main_tape_monitor", "?", OFF, operator.eq),
+    ("receiver.main_tape_monitor", "=", ON, operator.eq),
+    ("receiver.main_tape_monitor", "+", OFF, operator.eq),
 
-# Tape monitor / tape 1 is independent of sources
-("receiver.main_tape_monitor", "=", OFF, operator.eq),
-("receiver.main_tape_monitor", "?", OFF, operator.eq),
-("receiver.main_tape_monitor", "=", ON, operator.eq),
-("receiver.main_tape_monitor", "+", OFF, operator.eq),
+    ("receiver.main_speaker_a", "=", OFF, operator.eq),
+    ("receiver.main_speaker_a", "?", OFF, operator.eq),
+    ("receiver.main_speaker_a", "=", ON, operator.eq),
+    ("receiver.main_speaker_a", "?", ON, operator.eq),
+    ("receiver.main_speaker_a", "+", OFF, operator.eq),
+    ("receiver.main_speaker_a", "+", ON, operator.eq),
+    ("receiver.main_speaker_a", "-", OFF, operator.eq),
+    ("receiver.main_speaker_a", "-", ON, operator.eq),
 
-("receiver.main_speaker_a", "=", OFF, operator.eq),
-("receiver.main_speaker_a", "?", OFF, operator.eq),
-("receiver.main_speaker_a", "=", ON, operator.eq),
-("receiver.main_speaker_a", "?", ON, operator.eq),
-("receiver.main_speaker_a", "+", OFF, operator.eq),
-("receiver.main_speaker_a", "+", ON, operator.eq),
-("receiver.main_speaker_a", "-", OFF, operator.eq),
-("receiver.main_speaker_a", "-", ON, operator.eq),
+    ("receiver.main_speaker_b", "=", OFF, operator.eq),
+    ("receiver.main_speaker_b", "?", OFF, operator.eq),
 
-("receiver.main_speaker_b", "=", OFF, operator.eq),
-("receiver.main_speaker_b", "?", OFF, operator.eq),
-
-("receiver.main_power", "=", OFF, operator.eq),
+    ("receiver.main_power", "=", OFF, operator.eq),
 ]
 
+SerialTests = [
+    ("receiver.main_version", "?", "V1.02", operator.eq),
+    ("receiver.main_model", "?", "C356BEE", operator.eq),
+] + CommonTests
+
+TelnetTests = [
+    ("receiver.main_version", "?", "V2.10", operator.eq),
+    ("receiver.main_model", "?", "T787", operator.eq),
+] + CommonTests
+
 # The NAD Units to test
-NAD_Units = [(Fake_NAD_C_356BE(), SerialTests)]
+NAD_Units = [
+    (Fake_NAD_C_356BE(), SerialTests),
+    (Fake_NAD_Telnet(), TelnetTests),
+]
 
 
 def _test_command(receiver, func, command, response, op) -> None:
@@ -94,9 +110,6 @@ def _test_command(receiver, func, command, response, op) -> None:
 def _test_commands(receiver, tests) -> None:
     for func, command, response, op in tests:
         _test_command(receiver, func, command, response, op)
-
-    #assert receiver.main_power("?") in (ON, OFF)
-
 
 
 def test_protocol() -> None:

--- a/tests/test_nad_protocol.py
+++ b/tests/test_nad_protocol.py
@@ -14,10 +14,11 @@ class Fake_NAD_C_356BE(nad_receiver.NADReceiver):
         self.transport = Fake_NAD_C_356BE_Transport()
 
 
-def test_NAD_C_356BE() -> None:
-    # This test can be run with the real amplifier, just instantiate
-    # the real transport instead of the fake one
-    receiver = Fake_NAD_C_356BE()
+# The NAD Units to test
+NAD_Units = [Fake_NAD_C_356BE()]
+
+
+def _test_commands(receiver) -> None:
     assert receiver.main_power("?") in (ON, OFF)
 
     # switch off
@@ -88,3 +89,11 @@ def test_NAD_C_356BE() -> None:
     assert receiver.main_speaker_b("?") == OFF
 
     assert receiver.main_power("=", OFF) == OFF
+
+
+
+def test_protocol() -> None:
+    # This test can be run with the real amplifier, just instantiate
+    # the real transport instead of the fake one
+    for receiver in NAD_Units:
+        _test_commands(receiver)


### PR DESCRIPTION
These commit will allow one to run the test suite agains C356 or T787 or both at the same time

As more tests are added to the NADTelnet transport, I think this architectural change is good
to have