### PR TITLE
New Zone 2 commands

### DIFF
--- a/nad_receiver/__init__.py
+++ b/nad_receiver/__init__.py
@@ -118,10 +118,13 @@ class NADReceiver:
 
         Returns int
         """
+        return self._source('main', operator, value)
+
+    def _source(self, domain: str, operator: str, value: str) -> Optional[Union[int, str]]:
         if value is not None:
-            source = self.exec_command('main', 'source', operator, str(value))
+            source = self.exec_command(domain, 'source', operator, str(value))
         else:
-            source = self.exec_command('main', 'source', operator)
+            source = self.exec_command(domain, 'source', operator)
 
         if source is None:
             return None
@@ -132,6 +135,14 @@ class NADReceiver:
             # return source as string
             return source
         return None
+
+    def main_codec(self, operator: str, value: Optional[str] =None) -> Optional[str]:
+        """Execute Main.Audio.Codec."""
+        return self.exec_command('main', 'codec', operator, value)
+
+    def main_arc(self, operator: str, value: Optional[str] =None) -> Optional[str]:
+        """Execute Main.Video.ARC."""
+        return self.exec_command('main', 'arc', operator, value)
 
     def main_version(self, operator: str, value: Optional[str] =None) -> Optional[str]:
         """Execute Main.Version."""
@@ -164,6 +175,28 @@ class NADReceiver:
     def tuner_fm_preset(self, operator: str, value: Optional[str] =None) -> Optional[str]:
         """Execute Tuner.FM.Preset."""
         return self.exec_command('tuner', 'fm_preset', operator, value)
+
+    def _has_zone2(self) -> bool:
+        back_config = self.exec_command('main', 'back', "?")
+        if back_config is None or "zone2" not in back_config.lower():
+            return False
+        return True
+
+    def zone2_source(self, operator: str, value: Optional[str]=None) -> Optional[Union[int, str]]:
+        """
+        Execute Zone2.Source.
+
+        Returns int
+        """
+        if not self._has_zone2():
+            raise ValueError("Zone2 unavilable")
+        return self._source('zone2', operator, value)
+
+    def zone2_power(self, operator: str, value: Optional[str] =None) -> Optional[str]:
+        """Execute Zone2.Power."""
+        if not self._has_zone2():
+            raise ValueError("Zone2 unavilable")
+        return self.exec_command('zone2', 'power', operator, value)
 
 
 class NADReceiverTelnet(NADReceiver):

--- a/nad_receiver/__init__.py
+++ b/nad_receiver/__init__.py
@@ -73,10 +73,13 @@ class NADReceiver:
 
         Returns float
         """
+        return self._volume('main', operator, value)
+
+    def _volume(self, domain: str, operator: str, value: str) -> Optional[float]:
         if value is not None:
-            volume = self.exec_command('main', 'volume', operator, str(value))
+            volume = self.exec_command(domain, 'volume', operator, str(value))
         else:
-            volume = self.exec_command('main', 'volume', operator)
+            volume = self.exec_command(domain, 'volume', operator)
 
         if volume is None:
             return None
@@ -197,6 +200,22 @@ class NADReceiver:
         if not self._has_zone2():
             raise ValueError("Zone2 unavilable")
         return self.exec_command('zone2', 'power', operator, value)
+
+    def zone2_volume(self, operator: str, value: Optional[str] =None) -> Optional[float]:
+        """
+        Execute Zone2.Volume.
+
+        Returns float
+        """
+        if not self._has_zone2():
+            raise ValueError("Zone2 unavilable")
+        return self._volume('zone2', operator, value)
+
+    def zone2_listeningmode(self, operator: str, value: Optional[str] =None) -> Optional[str]:
+        """Execute Zone2.ListeningMode."""
+        if not self._has_zone2():
+            raise ValueError("Zone2 unavilable")
+        return self.exec_command('zone2', 'listeningmode', operator, value)
 
 
 class NADReceiverTelnet(NADReceiver):

--- a/nad_receiver/nad_commands.py
+++ b/nad_receiver/nad_commands.py
@@ -41,6 +41,18 @@ CMDS: Dict[str, Dict[str, Dict[str, Union[str, Iterable[str]]]]] = {
                 {'cmd': 'Main.Source',
                  'supported_operators': ['+', '-', '=', '?']
                  },
+            'codec':
+                {'cmd': 'Main.Audio.CODEC',
+                 'supported_operators': ['=', '?']
+                 },
+            'arc':
+                {'cmd': 'Main.Video.ARC',
+                 'supported_operators': ['=', '?']
+                 },
+            'back':
+                {'cmd': 'Main.Amp.Back',
+                 'supported_operators': ['?']
+                 },
             'version':
                 {'cmd': 'Main.Version',
                  'supported_operators': ['?']
@@ -88,5 +100,16 @@ CMDS: Dict[str, Dict[str, Dict[str, Union[str, Iterable[str]]]]] = {
                 {'cmd': 'Tuner.FM.Preset',
                  'supported_operators': ['+', '-', '=', '?']
                  }
+        },
+    'zone2':
+        {
+            'power':
+                {'cmd': 'Zone2.Power',
+                 'supported_operators': ['+', '-', '=', '?']
+                 },
+            'source':
+                {'cmd': 'Zone2.Source',
+                 'supported_operators': ['+', '-', '=', '?']
+                 },
         }
 }

--- a/nad_receiver/nad_commands.py
+++ b/nad_receiver/nad_commands.py
@@ -31,7 +31,7 @@ CMDS: Dict[str, Dict[str, Dict[str, Union[str, Iterable[str]]]]] = {
                  },
             'listeningmode':
                 {'cmd': 'Main.ListeningMode',
-                 'supported_operators': ['+', '-']
+                 'supported_operators': ['+', '-', '=', '?']
                  },
             'sleep':
                 {'cmd': 'Main.Sleep',
@@ -109,6 +109,14 @@ CMDS: Dict[str, Dict[str, Dict[str, Union[str, Iterable[str]]]]] = {
                  },
             'source':
                 {'cmd': 'Zone2.Source',
+                 'supported_operators': ['+', '-', '=', '?']
+                 },
+            'volume':
+                {'cmd': 'Zone2.Volume',
+                 'supported_operators': ['+', '-', '=', '?']
+                 },
+            'listeningmode':
+                {'cmd': 'Zone2.ListeningMode',
                  'supported_operators': ['+', '-', '=', '?']
                  },
         }


### PR DESCRIPTION
This PR adds a handful of Zone 2 commands as well as some commands available on AV receivers to get the status of ARC and the audio type. They work with my T758 but I don't know what they will do on other amps. I've split a couple of methods into a 'private' method shared across `Main` and `Zone2` and the zone test uses `Main.Amp.Back` to see if the amp is configured for 7.x or 2 zones.

I also changed `main_listeningmode` to allow assignment and query. At least on a T758 this is legal, and looking at the commands PDF for an older amp it seems supported too.