### PR TITLE
Multiline support

### DIFF
--- a/nad_receiver/__init__.py
+++ b/nad_receiver/__init__.py
@@ -118,10 +118,13 @@ class NADReceiver:
 
         Returns int
         """
+        return self._source('main', operator, value)
+
+    def _source(self, domain: str, operator: str, value: str) -> Optional[Union[int, str]]:
         if value is not None:
-            source = self.exec_command('main', 'source', operator, str(value))
+            source = self.exec_command(domain, 'source', operator, str(value))
         else:
-            source = self.exec_command('main', 'source', operator)
+            source = self.exec_command(domain, 'source', operator)
 
         if source is None:
             return None
@@ -132,6 +135,14 @@ class NADReceiver:
             # return source as string
             return source
         return None
+
+    def main_codec(self, operator: str, value: Optional[str] =None) -> Optional[str]:
+        """Execute Main.Audio.Codec."""
+        return self.exec_command('main', 'codec', operator, value)
+
+    def main_arc(self, operator: str, value: Optional[str] =None) -> Optional[str]:
+        """Execute Main.Video.ARC."""
+        return self.exec_command('main', 'arc', operator, value)
 
     def main_version(self, operator: str, value: Optional[str] =None) -> Optional[str]:
         """Execute Main.Version."""
@@ -164,6 +175,28 @@ class NADReceiver:
     def tuner_fm_preset(self, operator: str, value: Optional[str] =None) -> Optional[str]:
         """Execute Tuner.FM.Preset."""
         return self.exec_command('tuner', 'fm_preset', operator, value)
+
+    def _has_zone2(self) -> bool:
+        back_config = self.exec_command('main', 'back', "?")
+        if back_config is None or "zone2" not in back_config.lower():
+            return False
+        return True
+
+    def zone2_source(self, operator: str, value: Optional[str]=None) -> Optional[Union[int, str]]:
+        """
+        Execute Zone2.Source.
+
+        Returns int
+        """
+        if not self._has_zone2():
+            raise ValueError("Zone2 unavilable")
+        return self._source('zone2', operator, value)
+
+    def zone2_power(self, operator: str, value: Optional[str] =None) -> Optional[str]:
+        """Execute Zone2.Power."""
+        if not self._has_zone2():
+            raise ValueError("Zone2 unavilable")
+        return self.exec_command('zone2', 'power', operator, value)
 
 
 class NADReceiverTelnet(NADReceiver):

--- a/nad_receiver/__init__.py
+++ b/nad_receiver/__init__.py
@@ -73,10 +73,13 @@ class NADReceiver:
 
         Returns float
         """
+        return self._volume('main', operator, value)
+
+    def _volume(self, domain: str, operator: str, value: str) -> Optional[float]:
         if value is not None:
-            volume = self.exec_command('main', 'volume', operator, str(value))
+            volume = self.exec_command(domain, 'volume', operator, str(value))
         else:
-            volume = self.exec_command('main', 'volume', operator)
+            volume = self.exec_command(domain, 'volume', operator)
 
         if volume is None:
             return None
@@ -197,6 +200,22 @@ class NADReceiver:
         if not self._has_zone2():
             raise ValueError("Zone2 unavilable")
         return self.exec_command('zone2', 'power', operator, value)
+
+    def zone2_volume(self, operator: str, value: Optional[str] =None) -> Optional[float]:
+        """
+        Execute Zone2.Volume.
+
+        Returns float
+        """
+        if not self._has_zone2():
+            raise ValueError("Zone2 unavilable")
+        return self._volume('zone2', operator, value)
+
+    def zone2_listeningmode(self, operator: str, value: Optional[str] =None) -> Optional[str]:
+        """Execute Zone2.ListeningMode."""
+        if not self._has_zone2():
+            raise ValueError("Zone2 unavilable")
+        return self.exec_command('zone2', 'listeningmode', operator, value)
 
 
 class NADReceiverTelnet(NADReceiver):

--- a/nad_receiver/__init__.py
+++ b/nad_receiver/__init__.py
@@ -1,6 +1,5 @@
 """
 NAD has an RS232 interface to control the receiver.
-
 Not all receivers have all functions.
 Functions can be found on the NAD website: http://nadelectronics.com/software
 """
@@ -33,7 +32,6 @@ class NADReceiver:
     def exec_command(self, domain: str, function: str, operator: str, value: Optional[str] =None) -> Optional[str]:
         """
         Write a command to the receiver and read the value it returns.
-
         The receiver will always return a value, also when setting a value.
         """
         if operator in CMDS[domain][function]['supported_operators']:
@@ -70,16 +68,12 @@ class NADReceiver:
     def main_volume(self, operator: str, value: Optional[str] =None) -> Optional[float]:
         """
         Execute Main.Volume.
-
         Returns float
         """
-        return self._volume('main', operator, value)
-
-    def _volume(self, domain: str, operator: str, value: str) -> Optional[float]:
         if value is not None:
-            volume = self.exec_command(domain, 'volume', operator, str(value))
+            volume = self.exec_command('main', 'volume', operator, str(value))
         else:
-            volume = self.exec_command(domain, 'volume', operator)
+            volume = self.exec_command('main', 'volume', operator)
 
         if volume is None:
             return None
@@ -118,16 +112,12 @@ class NADReceiver:
     def main_source(self, operator: str, value: Optional[str]=None) -> Optional[Union[int, str]]:
         """
         Execute Main.Source.
-
         Returns int
         """
-        return self._source('main', operator, value)
-
-    def _source(self, domain: str, operator: str, value: str) -> Optional[Union[int, str]]:
         if value is not None:
-            source = self.exec_command(domain, 'source', operator, str(value))
+            source = self.exec_command('main', 'source', operator, str(value))
         else:
-            source = self.exec_command(domain, 'source', operator)
+            source = self.exec_command('main', 'source', operator)
 
         if source is None:
             return None
@@ -138,14 +128,6 @@ class NADReceiver:
             # return source as string
             return source
         return None
-
-    def main_codec(self, operator: str, value: Optional[str] =None) -> Optional[str]:
-        """Execute Main.Audio.Codec."""
-        return self.exec_command('main', 'codec', operator, value)
-
-    def main_arc(self, operator: str, value: Optional[str] =None) -> Optional[str]:
-        """Execute Main.Video.ARC."""
-        return self.exec_command('main', 'arc', operator, value)
 
     def main_version(self, operator: str, value: Optional[str] =None) -> Optional[str]:
         """Execute Main.Version."""
@@ -179,50 +161,11 @@ class NADReceiver:
         """Execute Tuner.FM.Preset."""
         return self.exec_command('tuner', 'fm_preset', operator, value)
 
-    def _has_zone2(self) -> bool:
-        back_config = self.exec_command('main', 'back', "?")
-        if back_config is None or "zone2" not in back_config.lower():
-            return False
-        return True
-
-    def zone2_source(self, operator: str, value: Optional[str]=None) -> Optional[Union[int, str]]:
-        """
-        Execute Zone2.Source.
-
-        Returns int
-        """
-        if not self._has_zone2():
-            raise ValueError("Zone2 unavilable")
-        return self._source('zone2', operator, value)
-
-    def zone2_power(self, operator: str, value: Optional[str] =None) -> Optional[str]:
-        """Execute Zone2.Power."""
-        if not self._has_zone2():
-            raise ValueError("Zone2 unavilable")
-        return self.exec_command('zone2', 'power', operator, value)
-
-    def zone2_volume(self, operator: str, value: Optional[str] =None) -> Optional[float]:
-        """
-        Execute Zone2.Volume.
-
-        Returns float
-        """
-        if not self._has_zone2():
-            raise ValueError("Zone2 unavilable")
-        return self._volume('zone2', operator, value)
-
-    def zone2_listeningmode(self, operator: str, value: Optional[str] =None) -> Optional[str]:
-        """Execute Zone2.ListeningMode."""
-        if not self._has_zone2():
-            raise ValueError("Zone2 unavilable")
-        return self.exec_command('zone2', 'listeningmode', operator, value)
-
 
 class NADReceiverTelnet(NADReceiver):
     """
     Support NAD amplifiers that use telnet for communication.
     Supports all commands from the RS232 base class
-
     Known supported model: Nad T787.
     """
 
@@ -234,7 +177,6 @@ class NADReceiverTelnet(NADReceiver):
 class NADReceiverTCP:
     """
     Support NAD amplifiers that use tcp for communication.
-
     Known supported model: Nad D 7050.
     """
 
@@ -302,7 +244,6 @@ class NADReceiverTCP:
     def status(self) -> Optional[Dict[str, Any]]:
         """
         Return the status of the device.
-
         Returns a dictionary with keys 'volume' (int 0-200) , 'power' (bool),
          'muted' (bool) and 'source' (str).
         """

--- a/nad_receiver/__init__.py
+++ b/nad_receiver/__init__.py
@@ -1,5 +1,6 @@
 """
 NAD has an RS232 interface to control the receiver.
+
 Not all receivers have all functions.
 Functions can be found on the NAD website: http://nadelectronics.com/software
 """
@@ -32,6 +33,7 @@ class NADReceiver:
     def exec_command(self, domain: str, function: str, operator: str, value: Optional[str] =None) -> Optional[str]:
         """
         Write a command to the receiver and read the value it returns.
+
         The receiver will always return a value, also when setting a value.
         """
         if operator in CMDS[domain][function]['supported_operators']:
@@ -68,6 +70,7 @@ class NADReceiver:
     def main_volume(self, operator: str, value: Optional[str] =None) -> Optional[float]:
         """
         Execute Main.Volume.
+
         Returns float
         """
         if value is not None:
@@ -112,6 +115,7 @@ class NADReceiver:
     def main_source(self, operator: str, value: Optional[str]=None) -> Optional[Union[int, str]]:
         """
         Execute Main.Source.
+
         Returns int
         """
         if value is not None:
@@ -166,6 +170,7 @@ class NADReceiverTelnet(NADReceiver):
     """
     Support NAD amplifiers that use telnet for communication.
     Supports all commands from the RS232 base class
+
     Known supported model: Nad T787.
     """
 
@@ -177,6 +182,7 @@ class NADReceiverTelnet(NADReceiver):
 class NADReceiverTCP:
     """
     Support NAD amplifiers that use tcp for communication.
+
     Known supported model: Nad D 7050.
     """
 
@@ -244,6 +250,7 @@ class NADReceiverTCP:
     def status(self) -> Optional[Dict[str, Any]]:
         """
         Return the status of the device.
+
         Returns a dictionary with keys 'volume' (int 0-200) , 'power' (bool),
          'muted' (bool) and 'source' (str).
         """

--- a/nad_receiver/nad_commands.py
+++ b/nad_receiver/nad_commands.py
@@ -1,6 +1,5 @@
 """
 Commands and operators used by NAD.
-
 CMDS[domain][function]
 """
 
@@ -31,7 +30,7 @@ CMDS: Dict[str, Dict[str, Dict[str, Union[str, Iterable[str]]]]] = {
                  },
             'listeningmode':
                 {'cmd': 'Main.ListeningMode',
-                 'supported_operators': ['+', '-', '=', '?']
+                 'supported_operators': ['+', '-']
                  },
             'sleep':
                 {'cmd': 'Main.Sleep',
@@ -40,18 +39,6 @@ CMDS: Dict[str, Dict[str, Dict[str, Union[str, Iterable[str]]]]] = {
             'source':
                 {'cmd': 'Main.Source',
                  'supported_operators': ['+', '-', '=', '?']
-                 },
-            'codec':
-                {'cmd': 'Main.Audio.CODEC',
-                 'supported_operators': ['=', '?']
-                 },
-            'arc':
-                {'cmd': 'Main.Video.ARC',
-                 'supported_operators': ['=', '?']
-                 },
-            'back':
-                {'cmd': 'Main.Amp.Back',
-                 'supported_operators': ['?']
                  },
             'version':
                 {'cmd': 'Main.Version',
@@ -100,24 +87,5 @@ CMDS: Dict[str, Dict[str, Dict[str, Union[str, Iterable[str]]]]] = {
                 {'cmd': 'Tuner.FM.Preset',
                  'supported_operators': ['+', '-', '=', '?']
                  }
-        },
-    'zone2':
-        {
-            'power':
-                {'cmd': 'Zone2.Power',
-                 'supported_operators': ['+', '-', '=', '?']
-                 },
-            'source':
-                {'cmd': 'Zone2.Source',
-                 'supported_operators': ['+', '-', '=', '?']
-                 },
-            'volume':
-                {'cmd': 'Zone2.Volume',
-                 'supported_operators': ['+', '-', '=', '?']
-                 },
-            'listeningmode':
-                {'cmd': 'Zone2.ListeningMode',
-                 'supported_operators': ['+', '-', '=', '?']
-                 },
         }
 }

--- a/nad_receiver/nad_commands.py
+++ b/nad_receiver/nad_commands.py
@@ -1,5 +1,6 @@
 """
 Commands and operators used by NAD.
+
 CMDS[domain][function]
 """
 

--- a/nad_receiver/nad_commands.py
+++ b/nad_receiver/nad_commands.py
@@ -41,6 +41,18 @@ CMDS: Dict[str, Dict[str, Dict[str, Union[str, Iterable[str]]]]] = {
                 {'cmd': 'Main.Source',
                  'supported_operators': ['+', '-', '=', '?']
                  },
+            'codec':
+                {'cmd': 'Main.Audio.CODEC',
+                 'supported_operators': ['=', '?']
+                 },
+            'arc':
+                {'cmd': 'Main.Video.ARC',
+                 'supported_operators': ['=', '?']
+                 },
+            'back':
+                {'cmd': 'Main.Amp.Back',
+                 'supported_operators': ['?']
+                 },
             'version':
                 {'cmd': 'Main.Version',
                  'supported_operators': ['?']
@@ -88,5 +100,16 @@ CMDS: Dict[str, Dict[str, Dict[str, Union[str, Iterable[str]]]]] = {
                 {'cmd': 'Tuner.FM.Preset',
                  'supported_operators': ['+', '-', '=', '?']
                  }
+        },
+    'zone2':
+        {
+            'power':
+                {'cmd': 'Zone2.Power',
+                 'supported_operators': ['+', '-', '=', '?']
+                 },
+            'source':
+                {'cmd': 'Zone2.Source',
+                 'supported_operators': ['+', '-', '=', '?']
+                 },
         }
 }

--- a/nad_receiver/nad_commands.py
+++ b/nad_receiver/nad_commands.py
@@ -31,7 +31,7 @@ CMDS: Dict[str, Dict[str, Dict[str, Union[str, Iterable[str]]]]] = {
                  },
             'listeningmode':
                 {'cmd': 'Main.ListeningMode',
-                 'supported_operators': ['+', '-']
+                 'supported_operators': ['+', '-', '=', '?']
                  },
             'sleep':
                 {'cmd': 'Main.Sleep',
@@ -109,6 +109,14 @@ CMDS: Dict[str, Dict[str, Dict[str, Union[str, Iterable[str]]]]] = {
                  },
             'source':
                 {'cmd': 'Zone2.Source',
+                 'supported_operators': ['+', '-', '=', '?']
+                 },
+            'volume':
+                {'cmd': 'Zone2.Volume',
+                 'supported_operators': ['+', '-', '=', '?']
+                 },
+            'listeningmode':
+                {'cmd': 'Zone2.ListeningMode',
                  'supported_operators': ['+', '-', '=', '?']
                  },
         }


### PR DESCRIPTION
This is the revised implementation of multiline support. Based on previous feedback:
* interface is separated out from standard interface
* implementation remains telnet-only for now
* there's a new `status_all` method and `status` method; the latter mimics the TCP `status` method
* multiline still relies on timeout happening to know when the end of the output happened
* use of `read_until` relies upon the underlying transport testing whether the connection is still open and raising an exception if not