### PR TITLE
Reset input buffer to get rid of irrelevant responses

### DIFF
--- a/nad_receiver/nad_transport.py
+++ b/nad_receiver/nad_transport.py
@@ -42,6 +42,7 @@ class SerialPortTransport(NadTransport):
         with self.lock:
             self._open_connection()
 
+            self.ser.reset_input_buffer()
             self.ser.write(f"\r{command}\r".encode("utf-8"))
             # To get complete messages, always read until we get '\r'
             # Messages will be of the form '\rMESSAGE\r' which


### PR DESCRIPTION
Reset input buffer to get rid of irrelevant responses

This fixes issues when the receiver sends updates when controlled directly from the receiver instead trough the library. For instance when changing the volume on my receiver (T755) a bunch of volume updates is sent to the serial line which fill up the input buffer.