### PR TITLE
Catch BrokenPipeError and try to reconnect

### DIFF
--- a/nad_receiver/nad_transport.py
+++ b/nad_receiver/nad_transport.py
@@ -1,5 +1,6 @@
 import abc
 import serial  # type: ignore
+import time
 import telnetlib
 import threading
 
@@ -166,13 +167,27 @@ class TelnetTransport(NadTransport):
 
     def communicate(self, cmd: str) -> str:
         if not self.telnet:
-            raise Exception("Connection is closed")
+            raise Exception("Connection is closed. Attempting to reconnect...")
+            self.open_connection()
 
-        _LOGGER.debug("Sending command: '%s'", cmd)
-        self.telnet.write(f"\n{cmd}\r".encode())
+        try:
+            _LOGGER.debug("Sending command: '%s'", cmd)
+            self.telnet.write(f"\n{cmd}\r".encode())
 
-        # Notice NAD response to command ends with \r and starts with \n
-        # E.g. b'\nMain.Power=On\r'
-        rsp = self.telnet.read_until(b"\r", self.timeout)
-        _LOGGER.debug("Read response: '%s'", str(rsp))
-        return rsp.strip().decode()
+            # Notice NAD response to command ends with \r and starts with \n
+            # E.g. b'\nMain.Power=On\r'
+            rsp = self.telnet.read_until(b"\r", self.timeout)
+            _LOGGER.debug("Read response: '%s'", str(rsp))
+            return rsp.strip().decode()
+
+        except (BrokenPipeError, ConnectionResetError):
+            _LOGGER.warning("Lost connection. Attempting to reconnect...")
+            self.close_connection()
+            self.open_connection()
+
+            # Delay a short period before retrying the command
+            time.sleep(1)
+
+            # Retry the command after reconnecting
+            return self.communicate(cmd)
+

--- a/nad_receiver/nad_transport.py
+++ b/nad_receiver/nad_transport.py
@@ -116,6 +116,10 @@ class TelnetTransportWrapper(NadTransport):
         except UnicodeError as ue:
             # Some unicode error, but connection is open
             _LOGGER.debug("Unicode error: %s", ue)
+        except (BrokenPipeError, ConnectionResetError):
+            _LOGGER.debug("Lost connection. Attempting to reconnect...")
+            self.nad_telnet.close_connection()
+            self.nad_telnet.open_connection()
 
         return rsp
 

--- a/nad_receiver/nad_transport.py
+++ b/nad_receiver/nad_transport.py
@@ -109,17 +109,13 @@ class TelnetTransportWrapper(NadTransport):
 
         try:
             rsp = self.nad_telnet.communicate(cmd)
-        except EOFError as cc:
+        except (EOFError,BrokenPipeError, ConnectionResetError) as cc:
             # Connection closed
             _LOGGER.debug("Connection closed: %s", cc)
             self.nad_telnet.close_connection()
         except UnicodeError as ue:
             # Some unicode error, but connection is open
             _LOGGER.debug("Unicode error: %s", ue)
-        except (BrokenPipeError, ConnectionResetError):
-            _LOGGER.debug("Lost connection. Attempting to reconnect...")
-            self.nad_telnet.close_connection()
-            self.nad_telnet.open_connection()
 
         return rsp
 

--- a/nad_receiver/nad_transport.py
+++ b/nad_receiver/nad_transport.py
@@ -1,6 +1,5 @@
 import abc
 import serial  # type: ignore
-import time
 import telnetlib
 import threading
 
@@ -167,27 +166,13 @@ class TelnetTransport(NadTransport):
 
     def communicate(self, cmd: str) -> str:
         if not self.telnet:
-            raise Exception("Connection is closed. Attempting to reconnect...")
-            self.open_connection()
+            raise Exception("Connection is closed")
 
-        try:
-            _LOGGER.debug("Sending command: '%s'", cmd)
-            self.telnet.write(f"\n{cmd}\r".encode())
+        _LOGGER.debug("Sending command: '%s'", cmd)
+        self.telnet.write(f"\n{cmd}\r".encode())
 
-            # Notice NAD response to command ends with \r and starts with \n
-            # E.g. b'\nMain.Power=On\r'
-            rsp = self.telnet.read_until(b"\r", self.timeout)
-            _LOGGER.debug("Read response: '%s'", str(rsp))
-            return rsp.strip().decode()
-
-        except (BrokenPipeError, ConnectionResetError):
-            _LOGGER.warning("Lost connection. Attempting to reconnect...")
-            self.close_connection()
-            self.open_connection()
-
-            # Delay a short period before retrying the command
-            time.sleep(1)
-
-            # Retry the command after reconnecting
-            return self.communicate(cmd)
-
+        # Notice NAD response to command ends with \r and starts with \n
+        # E.g. b'\nMain.Power=On\r'
+        rsp = self.telnet.read_until(b"\r", self.timeout)
+        _LOGGER.debug("Read response: '%s'", str(rsp))
+        return rsp.strip().decode()


### PR DESCRIPTION
I am using this python API with Home Assistant and it works fine with my NAD T758v3i.

However every time the telnet connection is lost (e.g. if the receiver was temporarily powered off by a external power plug), the API does not try to reconnect but instead permanently reports BrokenPipeError.

A detailed bug report is available at https://github.com/home-assistant/core/issues/92303

I could solve the connection problem with this quick change. However I do not have experience with python and this api, so If you think this code is not useful that is fine to me of course.