### PR TITLE
use underscore in description_file

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
 [metadata]
-description-file = README.md
+description_file = README.md


### PR DESCRIPTION
Fixes setup tools in modern python complaining:

.../lib/python3.14/site-packages/setuptools/dist.py:599: SetuptoolsDeprecationWarning: Invalid dash-separated key 'description-file' in 'metadata' (setup.cfg), please use the underscore name 'description_file' instead.
!!

        ********************************************************************************
        Usage of dash-separated 'description-file' will not be supported in future
        versions. Please use the underscore name 'description_file' instead.
        (Affected: nad_receiver).

        Available configuration options are listed in:
        https://setuptools.pypa.io/en/latest/userguide/declarative_config.html

        This deprecation is overdue, please update your project and remove deprecated
        calls to avoid build errors in the future.

        See https://github.com/pypa/setuptools/discussions/5011 for details.
        ********************************************************************************

!!
  opt = self._enforce_underscore(opt, section)
