### PR TITLE
fix ci: use available python versions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8]
+        python-version: [3.11, 3.14]
 
     steps:
     - uses: actions/checkout@v2

--- a/nad_receiver/nad_transport.py
+++ b/nad_receiver/nad_transport.py
@@ -1,6 +1,6 @@
 import abc
 import serial  # type: ignore
-import telnetlib
+import telnetlib  # type: ignore
 import threading
 
 from typing import Optional

--- a/nad_receiver/nad_transport.py
+++ b/nad_receiver/nad_transport.py
@@ -1,6 +1,6 @@
 import abc
 import serial  # type: ignore
-import telnetlib  # type: ignore
+from telnetlib3.telnetlib import Telnet  # type: ignore
 import threading
 
 from typing import Optional
@@ -130,7 +130,7 @@ class TelnetTransport(NadTransport):
 
     def __init__(self, host: str, port: int, timeout: int) -> None:
         """Create NADTelnet."""
-        self.telnet: Optional[telnetlib.Telnet] = None
+        self.telnet: Optional[Telnet] = None
         self.host = host
         self.port = port
         self.timeout = timeout
@@ -149,7 +149,7 @@ class TelnetTransport(NadTransport):
             raise Exception("Connection already open for host '%s:%s'" % (self.host, self.port))
 
         _LOGGER.debug("Open connection to: '%s:%s'" % (self.host, self.port))
-        self.telnet = telnetlib.Telnet(self.host, self.port, self.timeout)
+        self.telnet = Telnet(self.host, self.port, self.timeout)
 
     def close_connection(self) -> None:
         telnet = self.telnet

--- a/setup.py
+++ b/setup.py
@@ -8,5 +8,5 @@ setup(name='nad_receiver',
       author='joopert',
       license='MIT',
       packages=['nad_receiver'],
-      install_requires=['pyserial>=3.2.1'],
+      install_requires=['pyserial>=3.2.1', 'telnetlib3>=4.0.2'],
       zip_safe=True)


### PR DESCRIPTION
Seems like we cannot get anything older than 3.10 any more.
