### PR TITLE
Fix volume normalization for NAD C390DD

### DIFF
--- a/nad_receiver/__init__.py
+++ b/nad_receiver/__init__.py
@@ -80,8 +80,15 @@ class NADReceiver:
 
         if volume is None:
             return None
+
+        # The NAD C390DD (and perhaps other models) returns the literal string `dB` after the volume value.
+        # If present, we strip it so it can convert to float correctly.
+        normalized_volume = volume.strip()
+        if normalized_volume.lower().endswith("db"):
+            normalized_volume = normalized_volume[:-2].strip()
+
         try:
-            res = float(volume)
+            res = float(normalized_volume)
             return res
         except (ValueError):
             pass

--- a/nad_receiver/__init__.py
+++ b/nad_receiver/__init__.py
@@ -6,6 +6,7 @@ Functions can be found on the NAD website: http://nadelectronics.com/software
 """
 
 import codecs
+import re
 import socket
 from time import sleep
 from typing import Any, Dict, Iterable, Optional, Union
@@ -81,14 +82,14 @@ class NADReceiver:
         if volume is None:
             return None
 
-        # The NAD C390DD (and perhaps other models) returns the literal string `dB` after the volume value.
-        # If present, we strip it so it can convert to float correctly.
-        normalized_volume = volume.strip()
-        if normalized_volume.lower().endswith("db"):
-            normalized_volume = normalized_volume[:-2].strip()
+        # Some models append units (literally `dB`) or other text to the volume value.
+        # Instead, capture the decimal part of the value only so it can convert to float cleanly.
+        volume_match = re.match(r"-\d+(?:\.\d+)?", volume.strip())
+        if volume_match is None:
+            return None
 
         try:
-            res = float(normalized_volume)
+            res = float(volume_match.group())
             return res
         except (ValueError):
             pass

--- a/tests/test_nad_protocol.py
+++ b/tests/test_nad_protocol.py
@@ -14,6 +14,26 @@ class Fake_NAD_C_356BE(nad_receiver.NADReceiver):
         self.transport = Fake_NAD_C_356BE_Transport()
 
 
+@pytest.mark.parametrize(
+    ("response", "expected"),
+    [
+        ("-40", -40.0),
+        ("-40.5dB", -40.5),
+        ("-40.5 arbitrary suffix", -40.5),
+        ("NaN", None),
+        ("40", None)
+    ],
+)
+def test_main_volume_parses_leading_negative_decimal(
+    monkeypatch: pytest.MonkeyPatch, response: str, expected: float
+) -> None:
+    """Tests to check returned Main.Volume conversion."""
+    receiver = Fake_NAD_C_356BE()
+    monkeypatch.setattr(receiver, "exec_command", lambda *args: response)
+
+    assert receiver.main_volume("?") == expected
+
+
 def test_NAD_C_356BE() -> None:
     # This test can be run with the real amplifier, just instantiate
     # the real transport instead of the fake one


### PR DESCRIPTION
Normalize volume value by stripping 'dB' suffix for correct conversion.